### PR TITLE
Update nodejs version running actions from 12 to 16.

### DIFF
--- a/build-test-llvm-project/action.yml
+++ b/build-test-llvm-project/action.yml
@@ -14,5 +14,5 @@ inputs:
     default: 'check-all'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/configure-llvm-project/action.yml
+++ b/configure-llvm-project/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
     default: ${{ runner.os }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/get-llvm-project-src/action.yml
+++ b/get-llvm-project-src/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: ${{ github.repository }}
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/get-llvm-version/action.yml
+++ b/get-llvm-version/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'LLVM patch version'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/install-ninja/action.yml
+++ b/install-ninja/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ${{ runner.os }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/setup-windows/action.yml
+++ b/setup-windows/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Host Arch'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: main.js


### PR DESCRIPTION
Support for Node12 for GitHub JavaScript actions is being phased out due to Node12 being unsupported since April 2022 and will cease by "Summer 2023". Actions are advised to upgrade to Node16 by then, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Since this PR has the potential to breaking CI of the monorepo and possibly other downstream repos that use these actions, it will need thorough review and probably more testing. This is specifically true since I have only superficial understanding of how NodeJS and Github actions work. As a best effort, I have exercised all actions except `configure-llvm-project` (which I ***think*** is being exercised by `build-test-llvm-project` indirectly) through the CI jobs of [this](https://github.com/iree-org/iree-llvm-sandbox/pull/630) PR, which all ran fine (and produced the expected output in the case of `get-llvm-version`).