### PR TITLE
Update nodejs version running actions from 16 to 20.

### DIFF
--- a/build-test-llvm-project/action.yml
+++ b/build-test-llvm-project/action.yml
@@ -14,5 +14,5 @@ inputs:
     default: 'check-all'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'

--- a/configure-llvm-project/action.yml
+++ b/configure-llvm-project/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
     default: ${{ runner.os }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'

--- a/get-llvm-project-src/action.yml
+++ b/get-llvm-project-src/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: ${{ github.repository }}
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'

--- a/get-llvm-version/action.yml
+++ b/get-llvm-version/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'LLVM patch version'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/install-ninja/action.yml
+++ b/install-ninja/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ${{ runner.os }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'

--- a/issue-labeler/action.yml
+++ b/issue-labeler/action.yml
@@ -45,7 +45,7 @@ outputs:
     description: 'The labels that were removed by the action, as a stringified array.'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/index.js'
 branding:
   icon: 'activity'

--- a/setup-windows/action.yml
+++ b/setup-windows/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Host Arch'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: main.js


### PR DESCRIPTION
Node16 has ben EOL'd September 2023 and support on Github Actions has been dropped in early 2024. As a result, all workflows requesting Node16 are already forced to run on Node 20 since 3rd of June 2024, see the announcement by Github [here](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/).
This means the affected actions have been running on Node20 for two months already. Thus this change is purely cosmetic and should not break anything, but it should resolve warnings we are currently seeing on every CI job using this action:
`The following actions uses Node.js version which is deprecated and will be forced to run on node20: llvm/actions/install-ninja@main. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`